### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.5.2 (2025-12-08)
 
 - Allow to specify dependencies when using `use_effect` as a decorator
 - Transpiled `next` should now support a default parameter

--- a/pret/__init__.py
+++ b/pret/__init__.py
@@ -19,7 +19,7 @@ from .hooks import (
 )
 from .manager import server_only
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = [
     "component",


### PR DESCRIPTION
## Changelog

- Allow to specify dependencies when using `use_effect` as a decorator
- Transpiled `next` should now support a default parameter