### PR TITLE
Add load_store_snapshot and warn at create_store when a file already exist

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added a new `load_store_snapshot` function to load a Python snapshot of the store state without subscribing to updates or risking mutations. This can be useful for instance in Metanno to load the annotations in a read-only pure Python format for export or processing purposes.
+- We now warn users when they call `create_store` with initial data and a file already exists at the specified path, to prevent accidental overwriting of existing data.
+- `create_store` now also accepts data as a callable that returns the initial data, to support lazy initialization of the store state.
+
 ## v0.5.2 (2025-12-08)
 
 - Allow to specify dependencies when using `use_effect` as a decorator

--- a/docs/tutorials/interacting-with-the-server.md
+++ b/docs/tutorials/interacting-with-the-server.md
@@ -144,3 +144,15 @@ store = create_store({"count": 0}, sync="./shared_state.bin")
 ```
 
 If another instance of your application uses the same file path, all changes will be merged and synchronized between all clients and servers.
+
+## Loading a snapshot of the store
+
+If you want to load the current state of the store as a Python object without subscribing to updates or risking modifying it, you can use the `load_store_snapshot` function:
+
+```python
+from pret import load_store_snapshot
+
+snapshot = load_store_snapshot("./shared_state.bin")
+print(snapshot, type(snapshot))
+# Out: {'count': 42}, <class 'dict'>
+```

--- a/pret/__init__.py
+++ b/pret/__init__.py
@@ -5,7 +5,7 @@ __path__ = pkgutil.extend_path(__path__, __name__)
 from . import ipython_var_cleaner  # noqa: F401
 from .main import run
 from .render import component
-from .store import create_store
+from .store import create_store, load_store_snapshot
 from .hooks import (
     use_callback,
     use_effect,

--- a/tests/pytest/test_persistence.py
+++ b/tests/pytest/test_persistence.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from pret.store import create_store
+from pret.store import create_store, load_store_snapshot
 
 
 @pytest.mark.asyncio
@@ -44,7 +44,10 @@ async def test_hydrate_from_existing_file(tmp_path):
     state1.doc._persistence_finalizer.detach()
     state1.doc._persistence_finalizer = None
 
-    state2 = create_store({}, sync=path)
+    with pytest.warns(UserWarning) as warns:
+        state2 = create_store({}, sync=path)
+
+    assert "Initial data provided to create_store will be ignored" in warns[0].message.args[0]
     assert state2.doc.sync_id == state1.doc.sync_id
     await asyncio.sleep(0.05)
     assert state2["count"] == 7
@@ -52,3 +55,6 @@ async def test_hydrate_from_existing_file(tmp_path):
     await asyncio.sleep(0)
     state2.doc._persistence_finalizer.detach()
     state2.doc._persistence_finalizer = None
+
+    snapshot = load_store_snapshot(path)
+    assert snapshot["count"] == 7


### PR DESCRIPTION
- Added a new `load_store_snapshot` function to load a Python snapshot of the store state without subscribing to updates or risking mutations. This can be useful for instance in Metanno to load the annotations in a read-only pure Python format for export or processing purposes.
- We now warn users when they call `create_store` with initial data and a file already exists at the specified path, to prevent accidental overwriting of existing data.
- `create_store` now also accepts data as a callable that returns the initial data, to support lazy initialization of the store state.