### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.6.0 (2026-02-26)
 
 - Added a new `load_store_snapshot` function to load a Python snapshot of the store state without subscribing to updates or risking mutations. This can be useful for instance in Metanno to load the annotations in a read-only pure Python format for export or processing purposes.
 - We now warn users when they call `create_store` with initial data and a file already exists at the specified path, to prevent accidental overwriting of existing data.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pret",
   "main": "client/index.tsx",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "scripts": {
     "build": "jlpm clean && jlpm build:standalone && jlpm build:jupyter",
     "build:dev": "jlpm clean && jlpm build:standalone:dev && jlpm build:jupyter:dev",

--- a/pret/__init__.py
+++ b/pret/__init__.py
@@ -20,7 +20,7 @@ from .hooks import (
 )
 from .manager import server_only
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 
 __all__ = [
     "component",
@@ -36,4 +36,5 @@ __all__ = [
     "use_store_snapshot",
     "use_body_style",
     "use_event_callback",
+    "use_connection_status",
 ]


### PR DESCRIPTION
## Changelog 

- Added a new `load_store_snapshot` function to load a Python snapshot of the store state without subscribing to updates or risking mutations. This can be useful for instance in Metanno to load the annotations in a read-only pure Python format for export or processing purposes.
- We now warn users when they call `create_store` with initial data and a file already exists at the specified path, to prevent accidental overwriting of existing data.
- `create_store` now also accepts data as a callable that returns the initial data, to support lazy initialization of the store state.
- Jupyter outputs now send only `marshaler_id`/`chunk_idx` and fetch bundles on demand. This should reduce the notebooks file size drastically for apps containing large amounts of data, and speed up the rendering of outputs.
- New "Open in a new browser tab" command on Pret widgets in jupyter to create a new full-viewport view that overlays and hides jupyter simple presentation mode.
- New "Restart app" button when widget is detected as stale or kernel is down upon widget mounting
- Rendering a pret widget now autosaves the notebook to limit the kernel-notebook desynchronization issues
- All tutorials are now runnable notebooks, rendered identically as documentation pages
- New `transact` function to group mutations as a single transaction.