### PR TITLE
fix: make joy popup list visible in full-page mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.4 (2026-05-10)
+
+- Fix z-index issue to make Joy popup lists appear in full-page mode, while still keeping jupyter main body and modals hidden
+
 ## v0.6.3 (2026-05-08)
 
 - Avoid Transcrypt's silent failures by calling it as a subprocess instead of importing it.

--- a/client/jupyter/style.css
+++ b/client/jupyter/style.css
@@ -3,7 +3,8 @@
     height: 100%;
 }
 
-#main:has(~ #pret-fullpage-host) {
+/* Hide jupyter main view and modals when full page mode is enabled */
+body.pret-fullpage > #main, body.pret-fullpage > .jp-Dialog {
     display: none;
 }
 
@@ -12,7 +13,6 @@
     inset: 0;
     width: 100vw;
     height: 100vh;
-    z-index: 10001; /* just above jupyter modals */
     overflow: hidden;
     background: var(--jp-layout-color1);
 }

--- a/client/jupyter/widget.tsx
+++ b/client/jupyter/widget.tsx
@@ -12,6 +12,9 @@ export type PretViewData = {
   chunk_idx: number;
 };
 
+const FULLPAGE_HOST_ID = "pret-fullpage-host";
+const FULLPAGE_BODY_CLASS = "pret-fullpage";
+
 /**
  * A renderer for pret Views with Jupyter (Lumino) framework
  */
@@ -127,7 +130,7 @@ export class PretViewWidget extends LuminoWidget {
   }
 
   hideContent() {
-    const hasFullpage = document.getElementById("pret-fullpage-host") !== null;
+    const hasFullpage = document.getElementById(FULLPAGE_HOST_ID) !== null;
     if (!this.isVisible && this._isRendered) {
       if (!hasFullpage) {
         ReactDOM.unmountComponentAtNode(this._renderNode);
@@ -138,12 +141,16 @@ export class PretViewWidget extends LuminoWidget {
       this._fullpageNode = null;
       this._renderNode = this.node;
     }
+    document.body.classList.toggle(
+      FULLPAGE_BODY_CLASS,
+      document.getElementById(FULLPAGE_HOST_ID) !== null
+    );
   }
 
   dispose() {
     this._unsubscribeReadyChange?.();
     this._unsubscribeReadyChange = null;
-    const hasFullpage = document.getElementById("pret-fullpage-host") !== null;
+    const hasFullpage = document.getElementById(FULLPAGE_HOST_ID) !== null;
 
     if (this._isRendered) {
       if (!hasFullpage) {
@@ -154,6 +161,10 @@ export class PretViewWidget extends LuminoWidget {
     if (this._fullpageNode) {
       this._fullpageNode = null;
     }
+    document.body.classList.toggle(
+      FULLPAGE_BODY_CLASS,
+      document.getElementById(FULLPAGE_HOST_ID) !== null
+    );
     super.dispose();
   }
 
@@ -164,7 +175,7 @@ export class PretViewWidget extends LuminoWidget {
 
     const previousRenderNode = this._renderNode;
     const existingFullpageNode = document.getElementById(
-      "pret-fullpage-host"
+      FULLPAGE_HOST_ID
     ) as HTMLDivElement | null;
     const searchParams = new URLSearchParams(window.location.search);
     let fullpageCellParam = searchParams.get("pret-fullpage-cell");
@@ -209,7 +220,7 @@ export class PretViewWidget extends LuminoWidget {
         if (!this._fullpageNode) {
           this._fullpageNode =
             existingFullpageNode ?? document.createElement("div");
-          this._fullpageNode.id = "pret-fullpage-host";
+          this._fullpageNode.id = FULLPAGE_HOST_ID;
           if (!document.body.contains(this._fullpageNode)) {
             document.body.appendChild(this._fullpageNode);
           }
@@ -228,12 +239,16 @@ export class PretViewWidget extends LuminoWidget {
     } else {
       this._renderNode = this.node;
       if (this._fullpageNode) {
-        if (!document.getElementById("pret-fullpage-host")) {
+        if (!document.getElementById(FULLPAGE_HOST_ID)) {
           this._fullpageNode.remove();
         }
         this._fullpageNode = null;
       }
     }
+    document.body.classList.toggle(
+      FULLPAGE_BODY_CLASS,
+      document.getElementById(FULLPAGE_HOST_ID) !== null
+    );
 
     const Render = () => {
       if (!this.makeView) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pret",
   "main": "client/index.tsx",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "scripts": {
     "build": "jlpm clean && jlpm build:standalone && jlpm build:jupyter",
     "build:dev": "jlpm clean && jlpm build:standalone:dev && jlpm build:jupyter:dev",

--- a/pret/__init__.py
+++ b/pret/__init__.py
@@ -20,7 +20,7 @@ from .hooks import (
 )
 from .manager import server_only
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 __all__ = [
     "component",

--- a/tests/jupyter/full_page/run.spec.ts
+++ b/tests/jupyter/full_page/run.spec.ts
@@ -60,6 +60,7 @@ test.describe("Notebook Tests", () => {
 
     const fullPageHost = page.locator("#pret-fullpage-host");
     await fullPageHost.waitFor({ state: "visible" });
+    await expect(page.locator("body")).toHaveClass(/pret-fullpage/);
 
     const reloadButton = fullPageHost.locator(".pret-restart-app-button");
     await reloadButton.waitFor({ state: "visible" });


### PR DESCRIPTION
- Fix z-index issue to make Joy popup lists appear in full-page mode, while still keeping jupyter main body and modals hidden